### PR TITLE
fix: sandbox start timeout

### DIFF
--- a/packages/js/dist/container/server.js
+++ b/packages/js/dist/container/server.js
@@ -66,7 +66,7 @@ async function pingServer(port) {
         request.end();
     });
 }
-async function sandboxStarted(port, timeout = 20000) {
+async function sandboxStarted(port, timeout = 60000) {
     const checkUntil = Date.now() + timeout + 250;
     do {
         if (await pingServer(port)) { // eslint-disable-line no-await-in-loop

--- a/packages/js/src/container/server.ts
+++ b/packages/js/src/container/server.ts
@@ -55,7 +55,7 @@ async function pingServer(port: number): Promise<boolean> {
   });
 }
 
-async function sandboxStarted(port: number, timeout = 20_000): Promise<void> {
+async function sandboxStarted(port: number, timeout = 60_000): Promise<void> {
   const checkUntil = Date.now() + timeout + 250;
   do {
     if (await pingServer(port)) { // eslint-disable-line no-await-in-loop


### PR DESCRIPTION
Fixes: #125

Based on the testing, increase timeout setting to 60s would fix the issue. 

But a more comprehensive fix is to make the timeout configurable. 