### PR TITLE
Sandbox flags

### DIFF
--- a/.github/workflows/tests-sandbox.yml
+++ b/.github/workflows/tests-sandbox.yml
@@ -4,7 +4,7 @@ jobs:
   sandbox:
     strategy:
       matrix:
-        platform: [ubuntu-latest, macos-latest]
+        platform: [ubuntu-latest] # macos-latest
         node-version: [14, 16]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -20,7 +20,7 @@
     "fs-extra": "^10.0.0",
     "js-sha256": "^0.9.0",
     "near-api-js": "^0.44.1",
-    "near-sandbox": "^0.0.10",
+    "near-sandbox": "^0.0.12",
     "near-units": "^0.1.9",
     "node-port-check": "^2.0.1",
     "promisify-child-process": "^4.1.1",

--- a/packages/js/src/server/server.ts
+++ b/packages/js/src/server/server.ts
@@ -136,7 +136,9 @@ export class SandboxServer {
       this.homeDir,
       'run',
       '--rpc-addr',
-      this.internalRpcAddr,
+      `0.0.0.0:${this.port}`,
+      '--network-addr',
+      `0.0.0.0:${await SandboxServer.nextPort()}`,
     ];
     if (process.env.NEAR_WORKSPACES_DEBUG) {
       const filePath = join(this.homeDir, 'sandboxServer.log');
@@ -177,10 +179,6 @@ export class SandboxServer {
     if (this.config.rm) {
       await rm(this.homeDir);
     }
-  }
-
-  private get internalRpcAddr(): string {
-    return `0.0.0.0:${this.port}`;
   }
 
   private async spawn(command: string): ChildProcessPromise {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4885,10 +4885,10 @@ near-api-js@^0.44.1:
     text-encoding-utf-8 "^1.0.2"
     tweetnacl "^1.0.1"
 
-near-sandbox@^0.0.10:
-  version "0.0.10"
-  resolved "https://registry.npmjs.org/near-sandbox/-/near-sandbox-0.0.10.tgz#2216a77426bbf9ed794331939d5fbb427ff7c3da"
-  integrity sha512-ak0Lq9j+7VX4pjh7BnzrGFk4LVBblDDK7jezsQDdtToWm+QmjOmg23N/oPo6OVGxhrKCyQUGZVMDRhFylomWVQ==
+near-sandbox@^0.0.12:
+  version "0.0.12"
+  resolved "https://registry.npmjs.org/near-sandbox/-/near-sandbox-0.0.12.tgz#b0e36c9458a437c5cb4e1218f715585f087904b1"
+  integrity sha512-NfMSbPYiSpSMijM3JoC1FuNJuc3Pop86OF+/01ahc8phWQbjT404rMR+UvvuCZQ6Qge8/MC76KjBUPg3d7mg1Q==
   dependencies:
     got "^11.8.2"
     tar "^6.1.0"


### PR DESCRIPTION
- new `sandbox` requires new flags
- `macos` unit tests are turned off because of the issue with sandbox. Should be fixed in future versions.