### PR TITLE
Kill all sandbox processes

### DIFF
--- a/__tests__/01.basic-transactions.ava.ts
+++ b/__tests__/01.basic-transactions.ava.ts
@@ -32,7 +32,7 @@ test.beforeEach(async t => {
   t.context.accounts = {root, contract, ali};
 });
 
-test.afterEach(async t => {
+test.afterEach.always(async t => {
   // Stop Sandbox server
   await t.context.worker.tearDown().catch(error => {
     console.log('Failed to tear down the worker:', error);

--- a/__tests__/02.patch-state.ava.ts
+++ b/__tests__/02.patch-state.ava.ts
@@ -33,7 +33,7 @@ if (getNetworkFromEnv() === 'sandbox') {
     t.context.accounts = {root, contract, ali};
   });
 
-  test.afterEach(async t => {
+  test.afterEach.always(async t => {
     await t.context.worker.tearDown().catch(error => {
       console.log('Failed to tear down the worker:', error);
     });

--- a/__tests__/03.single-use-access-keys-with-linkdrop.ava.ts
+++ b/__tests__/03.single-use-access-keys-with-linkdrop.ava.ts
@@ -43,7 +43,7 @@ test.beforeEach(async t => {
   t.context.accounts = {root, linkdrop};
 });
 
-test.afterEach(async t => {
+test.afterEach.always(async t => {
   await t.context.worker.tearDown().catch(error => {
     console.log('Failed to tear down the worker:', error);
   });

--- a/__tests__/04.cross-contract-calls-with-fungible-token.ava.ts
+++ b/__tests__/04.cross-contract-calls-with-fungible-token.ava.ts
@@ -73,7 +73,7 @@ test.beforeEach(async t => {
   t.context.accounts = {root, ft, defi, ali};
 });
 
-test.afterEach(async t => {
+test.afterEach.always(async t => {
   await t.context.worker.tearDown().catch(error => {
     console.log('Failed to tear down the worker:', error);
   });

--- a/__tests__/05.spoon-contract-to-sandbox.ava.ts
+++ b/__tests__/05.spoon-contract-to-sandbox.ava.ts
@@ -36,7 +36,7 @@ test.beforeEach(async t => {
   t.context.worker = await Worker.init();
 });
 
-test.afterEach(async t => {
+test.afterEach.always(async t => {
   await t.context.worker.tearDown().catch(error => {
     console.log('Failed to tear down the worker:', error);
   });

--- a/__tests__/06.init-config.ava.ts
+++ b/__tests__/06.init-config.ava.ts
@@ -14,7 +14,7 @@ if (getNetworkFromEnv() === 'testnet') {
     });
   });
 
-  test.afterEach(async t => {
+  test.afterEach.always(async t => {
     await t.context.worker.tearDown().catch(error => {
       console.log('Failed to tear down the worker:', error);
     });

--- a/__tests__/07.resue-worker.ava.ts
+++ b/__tests__/07.resue-worker.ava.ts
@@ -27,7 +27,7 @@ test.before(async t => {
   t.context.accounts = {root, contract, ali};
 });
 
-test.after(async t => {
+test.after.always(async t => {
   await t.context.worker.tearDown().catch(error => {
     console.log('Failed to tear down the worker:', error);
   });

--- a/examples/simple-project/__tests__/test-status-message.ava.js
+++ b/examples/simple-project/__tests__/test-status-message.ava.js
@@ -27,7 +27,7 @@ test.beforeEach(async t => {
   t.context.accounts = {root, contract, ali};
 });
 
-test.afterEach(async t => {
+test.afterEach.always(async t => {
   // Stop Sandbox server
   await t.context.worker.tearDown().catch(error => {
     console.log('Failed to tear down the worker:', error);

--- a/packages/js/__tests__/account.ava.ts
+++ b/packages/js/__tests__/account.ava.ts
@@ -16,7 +16,7 @@ if (getNetworkFromEnv() === 'sandbox') {
     t.context.accounts = {root};
   });
 
-  test.afterEach(async t => {
+  test.afterEach.always(async t => {
     await t.context.worker.tearDown().catch(error => {
       console.log('Failed to tear down the worker:', error);
     });

--- a/packages/js/__tests__/record-builder.ava.ts
+++ b/packages/js/__tests__/record-builder.ava.ts
@@ -23,7 +23,7 @@ if (getNetworkFromEnv() === 'sandbox') {
     t.context.accounts = {root, contract, ali};
   });
 
-  test.afterEach(async t => {
+  test.afterEach.always(async t => {
     await t.context.worker.tearDown().catch(error => {
       console.log('Failed to tear down the worker:', error);
     });


### PR DESCRIPTION
Before this change, we were not stopping near-sandbox processes in case the test failed. With time it leads to high memory, CPU, and battery usage.
`afterEach.always(...)` solves the problem.