### PR TITLE
docs(readme): fix code block indentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ You can switch to testnet mode in three ways.
    const worker = await Worker.init({
      network: 'testnet',
      testnetMasterAccountId: '<yourAccountName>',
-  })
+   })
    ```
 
 2. Set the `NEAR_WORKSPACES_NETWORK` and `TESTNET_MASTER_ACCOUNT_ID` environment variables when running your tests:


### PR DESCRIPTION
The "running on testnet" section's numbered list was formatted poorly. The cause is a one-space indentation error.